### PR TITLE
Audit logs and fix an unavailability of the open data

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
     implementation("ch.qos.logback:logback-core:1.2.9")
 
     runtimeOnly("org.postgresql:postgresql")
+    implementation("org.hibernate:hibernate-envers:5.4.32.Final")
+    implementation("org.hibernate:hibernate-entitymanager:5.4.32.Final")
 
     testRuntimeOnly("com.h2database:h2")
 

--- a/backend/src/main/kotlin/cz/loono/backend/DataLoader.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/DataLoader.kt
@@ -1,8 +1,10 @@
 package cz.loono.backend
 
+import cz.loono.backend.api.exception.LoonoBackendException
 import cz.loono.backend.api.service.HealthcareProvidersService
 import cz.loono.backend.db.model.ServerProperties
 import cz.loono.backend.db.repository.ServerPropertiesRepository
+import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.stereotype.Component
@@ -14,9 +16,15 @@ class DataLoader(
     private val healthcareProvidersService: HealthcareProvidersService
 ) : ApplicationRunner {
 
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     override fun run(args: ApplicationArguments) {
         serverPropsSetup()
-        healthcareProvidersService.updateData()
+        try {
+            healthcareProvidersService.updateData()
+        } catch (e: LoonoBackendException) {
+            logger.warn("Initial update of data failed. Continuing without it...")
+        }
     }
 
     @Transactional

--- a/backend/src/main/kotlin/cz/loono/backend/api/service/HealthcareProvidersService.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/api/service/HealthcareProvidersService.kt
@@ -26,11 +26,8 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
-import java.io.BufferedOutputStream
-import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
-import java.io.OutputStreamWriter
+import java.io.*
+import java.net.ConnectException
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
@@ -88,7 +85,16 @@ class HealthcareProvidersService(
     @Synchronized
     fun updateData(): UpdateStatusMessageDto {
         updating = true
-        val input = URL(OPEN_DATA_URL).openStream()
+        val input: InputStream
+        try {
+            input = URL(OPEN_DATA_URL).openStream()
+        } catch (e: ConnectException) {
+            throw LoonoBackendException(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                errorCode = HttpStatus.SERVICE_UNAVAILABLE.value().toString(),
+                errorMessage = "New open data are not available."
+            )
+        }
         val providers = HealthcareCSVParser().parse(input)
         if (providers.isNotEmpty()) {
             updating = true

--- a/backend/src/main/kotlin/cz/loono/backend/db/model/Account.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/db/model/Account.kt
@@ -1,6 +1,7 @@
 package cz.loono.backend.db.model
 
 import org.hibernate.Hibernate
+import org.hibernate.envers.Audited
 import java.time.LocalDate
 import java.util.Objects
 import javax.persistence.CascadeType
@@ -16,6 +17,7 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "\"account\"")
+@Audited
 data class Account(
 
     @Id

--- a/backend/src/main/kotlin/cz/loono/backend/db/model/ExaminationRecord.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/db/model/ExaminationRecord.kt
@@ -3,6 +3,7 @@ package cz.loono.backend.db.model
 import cz.loono.backend.api.dto.ExaminationStatusDto
 import cz.loono.backend.api.dto.ExaminationTypeEnumDto
 import org.hibernate.Hibernate
+import org.hibernate.envers.Audited
 import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.Column
@@ -15,6 +16,7 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "\"examination_record\"")
+@Audited
 data class ExaminationRecord(
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/backend/src/main/kotlin/cz/loono/backend/db/model/HealthcareCategory.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/db/model/HealthcareCategory.kt
@@ -1,5 +1,6 @@
 package cz.loono.backend.db.model
 
+import org.hibernate.envers.Audited
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
@@ -10,6 +11,7 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "\"healthcare_category\"")
+@Audited
 data class HealthcareCategory(
 
     @Id

--- a/backend/src/main/kotlin/cz/loono/backend/db/model/HealthcareProvider.kt
+++ b/backend/src/main/kotlin/cz/loono/backend/db/model/HealthcareProvider.kt
@@ -1,6 +1,7 @@
 package cz.loono.backend.db.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import org.hibernate.envers.Audited
 import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -15,6 +16,7 @@ import javax.persistence.Table
 @Entity
 @IdClass(HealthcareProviderId::class)
 @Table(name = "\"healthcare_provider\"")
+@Audited
 data class HealthcareProvider(
 
     @Id


### PR DESCRIPTION
Revision tables should be generated automatically. The audit tables copy all audited fields from the entity's table with two fields, REVTYPE (values are: “0” for adding, “1” for updating, “2” for removing an entity) and REV.

Besides these, an extra table named REVINFO will be generated by default, it includes two important fields, REV and REVTSTMP and records the timestamp of every revision.

Example:
![image](https://user-images.githubusercontent.com/13236988/151337396-535090f0-6aef-4561-a1a5-ede43fadfd15.png)
